### PR TITLE
ContentSize now properly wraps around the ends

### DIFF
--- a/ring.go
+++ b/ring.go
@@ -56,7 +56,7 @@ func (r *Ring) ContentSize() int {
 	} else {
 		difference := (r.head - r.tail)
 		if difference < 0 {
-			difference = -difference
+			difference += r.capacity()
 		}
 		return difference + 1
 	}


### PR DESCRIPTION
After the ring buffer wraps around the end, ContentSize() gets pretty screwy and doesn't take into account the fact that it needs to wrap around the ends, instead just "short circuiting" the other way. Changing the special case to this seems to work great.

```
if difference < 0 {
	difference += r.capacity()
}
```

Tested to work with this.

```
for i := 0; i < 25; i++ {
	if i >= 10 && i < 15 {
		ring.Dequeue()
	} else {
		ring.Enqueue(i)
	}
	fmt.Printf("RingState: %d/%d Values: %v\n", ring.ContentSize(), ring.Capacity(), ring.Values())
}
```