### PR TITLE
Revert "bug when set capacity : if head < tail we have nil values when dequeu…"

### DIFF
--- a/ring.go
+++ b/ring.go
@@ -185,24 +185,5 @@ func (r *Ring) extend(size int) {
 	for i := range newb {
 		newb[i] = nil
 	}
-	if r.head >= r.tail {
-		r.buff = append(r.buff, newb...)
-	} else {
-		if r.head == -1 {
-			r.buff = append(r.buff, newb...)
-		} else {
-			part1 := make([]interface{}, len(r.buff[:r.head+1]))
-			copy(part1, r.buff[:r.head+1])
-			part2 := make([]interface{}, len(r.buff[r.tail:]))
-			copy(part2, r.buff[r.tail:])
-			r.buff = append(r.buff, newb...)
-			r.tail = r.mod(r.tail + len(newb))
-			copy(r.buff[:r.head+1], part1)
-			copy(r.buff[r.head+1:r.tail], newb)
-			copy(r.buff[r.tail:], part2)
-
-		}
-
-	}
-
+	r.buff = append(r.buff, newb...)
 }

--- a/ring_test.go
+++ b/ring_test.go
@@ -27,47 +27,6 @@ func TestSavesSomeData(t *testing.T) {
 	}
 }
 
-func TestCapacity(t *testing.T) {
-	r := Ring{}
-	r.SetCapacity(10)
-	for i := 0; i < 7; i++ {
-		r.Enqueue(i)
-	}
-	r.SetCapacity(11)
-	for i := 7; i < 11; i++ {
-		r.Enqueue(i)
-	}
-	for i := 0; i < 11; i++ {
-		x := r.Dequeue()
-		if x != i {
-			t.Fatal("Unexpected response", x, "wanted", i)
-		}
-	}
-}
-
-func TestCapacityWithOverflow(t *testing.T) {
-	r := Ring{}
-	r.SetCapacity(5)
-	for i := 0; i < 7; i++ {
-		r.Enqueue(i)
-	}
-
-	r.SetCapacity(9)
-
-	for i := 2; i < 5; i++ {
-		x := r.Dequeue()
-		if x != i {
-			t.Fatal("Unexpected response", x, "wanted", i)
-		}
-	}
-	for i := 5; i < 7; i++ {
-		x := r.Dequeue()
-		if x != i {
-			t.Fatal("Unexpected response", x, "wanted", i)
-		}
-	}
-}
-
 func TestReusesBuffer(t *testing.T) {
 	r := Ring{}
 	r.SetCapacity(10)


### PR DESCRIPTION
Reverts zealws/golang-ring#7

This commit causes a transient unit-test failure which I did not realize before merging.