### PR TITLE
Dequeued items should be un-referenced to get GC'ed

### DIFF
--- a/ring.go
+++ b/ring.go
@@ -92,6 +92,7 @@ func (r *Ring) Dequeue() interface{} {
 		return nil
 	}
 	v := r.get(r.tail)
+	r.set(r.tail, nil)
 	if r.tail == r.head {
 		r.head = -1
 		r.tail = 0


### PR DESCRIPTION
@zealws
Items which were dequeued from the queue should be un-referenced, otherwise memory usage will never go down.
e.g. if in point of time we had 100 items in the queue which holds 10MB in total, after dequeuing all the items and reaching empty queue, the underlying buffer still has references to the 100 items which dequeued, thus, garbage collection will never free the memory.
Issue: https://github.com/zealws/golang-ring/issues/9